### PR TITLE
Got some tests passsing for new motor

### DIFF
--- a/aviary/subsystems/propulsion/motor/test/test_motor_map.py
+++ b/aviary/subsystems/propulsion/motor/test/test_motor_map.py
@@ -16,13 +16,9 @@ class TestGearbox(unittest.TestCase):
 
         prob = om.Problem()
 
-        prob.model.add_subsystem(
-            'motor_map',
-            MotorMap(
-                num_nodes=3, motor_model='aviary/models/motors/electric_motor_1800Nm_6000rpm.csv'
-            ),
-            promotes=['*'],
-        )
+        motor_map = MotorMap(num_nodes=3)
+        motor_map.options[Aircraft.Engine.Motor.DATA_FILE] = 'aviary/models/motors/electric_motor_1800Nm_6000rpm.csv'
+        prob.model.add_subsystem('motor_map', motor_map, promotes=['*'])
 
         prob.setup(force_alloc_complex=True)
 

--- a/aviary/subsystems/propulsion/test/test_turboprop_model.py
+++ b/aviary/subsystems/propulsion/test/test_turboprop_model.py
@@ -83,14 +83,17 @@ class TurbopropMissionTest(unittest.TestCase):
             promotes=['*'],
         )
 
-        self.prob.model.add_subsystem(
+        # Put it all in an outer group called "propulsion" so that model structure looks like
+        # aviary for model options.
+        propulsion_group = self.prob.model.add_subsystem('propulsion', om.Group(), promotes=['*'])
+        propulsion_group.add_subsystem(
             engine.name,
             subsys=engine.build_mission(num_nodes=num_nodes, aviary_inputs=options, **kwargs),
             promotes_inputs=['*'],
             promotes_outputs=['*'],
         )
 
-        setup_model_options(self.prob, options)
+        setup_model_options(self.prob, options, engine_models=[engine])
 
         self.prob.setup(force_alloc_complex=False)
         self.prob.set_val(Aircraft.Engine.SCALE_FACTOR, 1, units='unitless')

--- a/aviary/variable_info/functions.py
+++ b/aviary/variable_info/functions.py
@@ -571,51 +571,46 @@ def setup_model_options(
         prefix = ''  # the original default value
     prob.model_options[f'{prefix}*'] = extract_options(aviary_inputs, meta_data)
 
-    # Multi-engines need to index into their options.
-    try:
-        num = aviary_inputs.get_val(Aircraft.Engine.NUM_ENGINES)
-        if isinstance(num, int):
-            num_engine_models = 1
-        else:
-            num_engine_models = len(aviary_inputs.get_val(Aircraft.Engine.NUM_ENGINES))
-    except KeyError:
-        # No engine data.
-        return
-
     # TODO: Modify this method for multi mission/model.
 
-    if num_engine_models > 1:
-        if engine_models is None:
-            # Required in multi-mission cases
-            if group is None:
-                engine_models = prob.model.engine_models
-            else:
-                engine_models = group.engine_models
+    if engine_models is None:
+        # Required in multi-mission cases
+        if group is None:
+            src = prob.model
+        else:
+            src = group
 
-        for idx in range(num_engine_models):
-            eng_name = engine_models[idx].name
+        if not hasattr(src, 'engine_models'):
+            # In a unit-test context, this function can be used without an aviary model.
+            return
 
-            # TODO: For future flexibility, need get a list of options per engine (these are
-            # EngineDeck required options), so custom multiengine works
-            opt_names = [
-                Aircraft.Engine.SCALE_PERFORMANCE,
-                Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER,
-                Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER,
-                Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM,
-                Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM,
-            ]
-            opt_names_units = [
-                Aircraft.Engine.REFERENCE_SLS_THRUST,
-                Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION,
-            ]
-            opts = {}
-            for key in opt_names:
-                if key in aviary_inputs:
-                    opts[key] = aviary_inputs.get_item(key)[0][idx]
-            for key in opt_names_units:
-                if key in aviary_inputs:
-                    val, units = aviary_inputs.get_item(key)
-                    opts[key] = (val[idx], units)
+        engine_models = src.engine_models
 
-            path = f'{prefix}*propulsion.{eng_name}*'
-            prob.model_options[path] = opts
+    for idx, engine_model in enumerate(engine_models):
+        eng_name = engine_model.name
+
+        # TODO: For future flexibility, need get a list of options per engine (these are
+        # EngineDeck required options), so custom multiengine works
+        opt_names = [
+            Aircraft.Engine.Motor.DATA_FILE,
+            Aircraft.Engine.SCALE_PERFORMANCE,
+            Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER,
+            Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER,
+            Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM,
+            Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM,
+        ]
+        opt_names_units = [
+            Aircraft.Engine.REFERENCE_SLS_THRUST,
+            Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION,
+        ]
+        opts = {}
+        for key in opt_names:
+            if key in aviary_inputs:
+                opts[key] = aviary_inputs.get_item(key)[0][idx]
+        for key in opt_names_units:
+            if key in aviary_inputs:
+                val, units = aviary_inputs.get_item(key)
+                opts[key] = (val[idx], units)
+
+        path = f'{prefix}*propulsion.{eng_name}*'
+        prob.model_options[path] = opts


### PR DESCRIPTION
### Summary

1. Reworked the model option processor so that we also remove the "brackets" when setting options on single-engine models. We were getting lucky in that the handful of options that were inadvertently kept as lists didn't break any calculations.
2. Adjusted the turboprop_model unit test to be more like an Aviary model so that the model options glob patterns find the engine components.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None